### PR TITLE
🐛 FIX: Keyword Tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"Shade of Purple",
 		"Cobalt",
 		"VSCode Power User",
-		"coblat 3"
+		"cobalt 3"
 	],
 	"contributes": {
 		"themes": [


### PR DESCRIPTION
There's a typo `coblat` -> `cobalt`