### PR TITLE
Lighten editorSuggestWidget.selectedBackground color

### DIFF
--- a/themes/shades-of-purple-color-theme.json
+++ b/themes/shades-of-purple-color-theme.json
@@ -134,7 +134,7 @@
 		"editorSuggestWidget.border": "#1F1F41",
 		"editorSuggestWidget.foreground": "#A599E9",
 		"editorSuggestWidget.highlightForeground": "#FAD000",
-		"editorSuggestWidget.selectedBackground": "#222244",
+		"editorSuggestWidget.selectedBackground": "#2D2B55",
 
 		// Debug.
 		// https://code.visualstudio.com/docs/getstarted/theme-color-reference#_debug


### PR DESCRIPTION
In using the theme I noticed it was really difficult to see the selected item in the Suggestion Widget unless I moused over it. This lightens the `editorSuggestWidget.selectedBackground` color to match the `list.hoverBackground` color, and makes it easier to see the selected item without having to use the mouse.