### PR TITLE
🐛 FIX: Change Terminal ansiBrightWhite value to white.

### DIFF
--- a/themes/shades-of-purple-color-theme.json
+++ b/themes/shades-of-purple-color-theme.json
@@ -286,7 +286,7 @@
 		"terminal.ansiBrightBlue": "#6943FF",
 		"terminal.ansiBrightMagenta": "#FB94FF",
 		"terminal.ansiBrightCyan": "#80FCFF",
-		"terminal.ansiBrightWhite": "#2D2B55",
+		"terminal.ansiBrightWhite": "#FFFFFF",
 		"terminal.background": "#1E1E3F",
 		"terminal.foreground": "#FFFFFF",
 		"terminalCursor.background": "#FAD000",


### PR DESCRIPTION
This fixes an issue with the terminal (in my case, WSL), where if text is being printed out with the Bright White ANSI escape code, the text will be almost completely unreadable (_see image below_), due to the value of `terminal.ansiBrightWhite` being a dark-purple shade (`#2D2B55`) that is very close to the terminal's background color, instead of pure white.

![Code_2019-11-24_23-27-30](https://user-images.githubusercontent.com/3251495/69503070-4afccc80-0f16-11ea-87b2-d82da48e4a24.png)
