### PR TITLE
Make Super Dark's textLink's legible

### DIFF
--- a/themes/shades-of-purple-color-theme-super-dark.json
+++ b/themes/shades-of-purple-color-theme-super-dark.json
@@ -324,8 +324,8 @@
 		"textBlockQuote.background": "#15152b",
 		"textBlockQuote.border": "#6943FF",
 		"textCodeBlock.background": "#15152b",
-		"textLink.activeForeground": "#5706a2",
-		"textLink.foreground": "#5706a2",
+		"textLink.activeForeground": "#B362FF",
+		"textLink.foreground": "#FAD000",
 		"textPreformat.foreground": "#FAD000",
 		"textSeparator.foreground": "#15152b",
 


### PR DESCRIPTION
Change textLink.foreground and textLink.activeForeground to use other theme colors that will provide the level of contrast necessary to be easily read when used on the dark background color.

Fixes #136 