### PR TITLE
Set super dark's menu.selectionBackground

### DIFF
--- a/themes/shades-of-purple-color-theme-super-dark.json
+++ b/themes/shades-of-purple-color-theme-super-dark.json
@@ -367,6 +367,7 @@
 
 		// Customizable menu.
 		"menu.separatorBackground": "#A599E9",
+		"menu.selectionBackground": "#6943ff62",
 
 		// Tab stops.
 		"editor.snippetTabstopHighlightBackground": "#6943ff62",


### PR DESCRIPTION
Using a color from elsewhere in the super dark theme to make the currently selected menu item more visible. 

The color used for `activityBar.activeBorder` seems like a good middle ground of not too bright (it is "super dark," after all) and not too dark for the menu (need some contrast).

Fixes #147 

